### PR TITLE
Update doc to add info on self signed cas certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ the application server in the [`web.xml`](https://github.com/UniconLabs/cas-samp
 
 * Create a Java keystore at `/etc/cas/jetty/thekeystore` with the password `changeit`.
 * Import your server certificate inside this keystore.
+* If your CAS server certificate is self signed, import it in the system global keystore (/etc/pki/java/cacerts on some systems)
 
 ```bash
 mvn clean package jetty:run-forked


### PR DESCRIPTION
I spent hours on this.
Trying to add the cas server certificate in /etc/cas/jetty/thekeystore : no success.
I also tried to separate the trust store in another file changing jetty.ssl.truststore.path : no success.

Always had the error :
sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target

Finally, adding it to the global keystore solved my problem.